### PR TITLE
Pin myst_parser to 0.11.2 to avoid no markdown_it.extensions.dollarmath

### DIFF
--- a/docs/source/fixes/index.md
+++ b/docs/source/fixes/index.md
@@ -133,6 +133,7 @@ Then we could use React Intersection Obsever libraries.
 - [React Intersection Observer (thebuilder)](https://github.com/thebuilder/react-intersection-observer) ([storybook](https://react-intersection-observer.now.sh))
 - [React Intersection Observer (researchgate)](https://github.com/researchgate/react-intersection-observer) ([storybook](https://researchgate.github.io/react-intersection-observer))
 - [React Cool Inview](https://github.com/wellyshen/react-cool-inview) ([example](https://react-cool-inview.netlify.app))
+- [react-infinite-grid-scroller](https://github.com/HenrikBechmann/react-infinite-grid-scroller) (horizontal and vertical scrolling)
 
 ### React Virtualized / Windowing
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         ],
         # Note: This is only required for internal use
         "rtd": [
-            "myst_parser",
+            "myst_parser==0.11.2",
             "markdown-it-py~=0.4.5",
             "pyyaml",
             "docutils>=0.15",


### PR DESCRIPTION
Yesterday myst-parser 0.12.0 has been published (https://pypi.org/project/myst-parser/0.12.0) and RTD build is failing with

```
    from myst_parser.main import default_parser, MdParserConfig
  File "/home/docs/checkouts/readthedocs.org/user_builds/jupyterlab-benchmarks/envs/latest/lib/python3.7/site-packages/myst_parser/main.py", line 13, in <module>
    from markdown_it.extensions.dollarmath import dollarmath_plugin
ModuleNotFoundError: No module named 'markdown_it.extensions.dollarmath'
```

Pinning  to 0.11.2 to hopefully fix this 

cc/ @choldgraf