### PR TITLE
Name shadow-dom ci job

### DIFF
--- a/.github/workflows/linux-manyCells-manyOutputs-shadow-dom.yml
+++ b/.github/workflows/linux-manyCells-manyOutputs-shadow-dom.yml
@@ -1,4 +1,4 @@
-name: Linux-manyCells-manyOutputs
+name: Linux-manyCells-manyOutputs-shadow-dom
 on:
   push: 
   schedule:


### PR DESCRIPTION
Name shadow-dom ci job so we can find it back easily in the GitHub Actions.