### PR TITLE
Use @jupyterlab-benchmarks to publish in npm

### DIFF
--- a/extensions/fixed-data-table/README.md
+++ b/extensions/fixed-data-table/README.md
@@ -1,4 +1,4 @@
-# fdtmime
+# @jupyterlab-benchmarks/table-render
 
 A JupyterLab extension for rendering table files.
 
@@ -9,7 +9,7 @@ A JupyterLab extension for rendering table files.
 ## Installation
 
 ```bash
-jupyter labextension install fdtmime
+jupyter labextension install @jupyterlab-benchmarks/table-render
 ```
 
 ## Development

--- a/extensions/fixed-data-table/package.json
+++ b/extensions/fixed-data-table/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "fdtmime",
+  "name": "@jupyterlab-benchmarks/table-render",
   "version": "0.1.0",
   "description": "A JupyterLab extension for rendering table files.",
   "author": " <>",
+  "private": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "style": "style/index.css",
@@ -24,10 +25,10 @@
     "preinstall": "tsc",
     "prepare": "npm run clean && npm run build",
     "watch": "tsc -w",
-    "extension:install": "jupyter labextension install fdtmime",
-    "extension:uninstall": "jupyter labextension uninstall  fdtmime",
-    "extension:enable": "jupyter labextension enable fdtmime",
-    "extension:disable": "jupyter labextension disable fdtmime"
+    "extension:install": "jupyter labextension install @jupyterlab-benchmarks/table-render",
+    "extension:uninstall": "jupyter labextension uninstall  @jupyterlab-benchmarks/table-render",
+    "extension:enable": "jupyter labextension enable @jupyterlab-benchmarks/table-render",
+    "extension:disable": "jupyter labextension disable @jupyterlab-benchmarks/table-render"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^2.1.1",


### PR DESCRIPTION
This uses @jupyterlab-benchmarks organisation to publish the custom extensions we use in the benchmarks.

@goanpeca can you communicate me your npm username so I can add you to the org?