### PR TITLE
Pin vega-lite via `resolutions` in top-level `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "devDependencies": {
     "lerna": "^3.22.1",
     "rimraf": "^3.0.2"
+  },
+  "resolutions": {
+    "vega-lite": "~5.5.0"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -25,8 +25,5 @@
     "path": "~0.12.7",
     "rimraf": "^3.0.2",
     "typescript": "~4.1.3"
-  },
-  "resolutions": {
-    "vega-lite": "~5.5.0"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -25,5 +25,8 @@
     "path": "~0.12.7",
     "rimraf": "^3.0.2",
     "typescript": "~4.1.3"
+  },
+  "resolutions": {
+    "vega-lite": "~5.5.0"
   }
 }


### PR DESCRIPTION
Fixes #121, maybe supersedes #123?